### PR TITLE
chore: add CI workflows, clean up package.json exports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm test

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,8 +30,14 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Lint
+        run: npm run lint
+
       - name: Build carousel
         run: npm run build
+
+      - name: Test
+        run: npm test
 
       - name: Build docs
         run: npx vitepress build docs

--- a/package.json
+++ b/package.json
@@ -4,11 +4,35 @@
   "description": "Timed continuous carousel that uses vanilla JavaScript & CSS animations.",
   "main": "dist/continuous-carousel.js",
   "module": "dist/continuous-carousel.esm.js",
+  "types": "./types/index.d.ts",
+  "sideEffects": [
+    "*.css"
+  ],
+  "files": [
+    "dist/",
+    "src/",
+    "types/"
+  ],
+  "keywords": [
+    "carousel",
+    "slider",
+    "vanilla-js",
+    "css-animations",
+    "continuous",
+    "a11y"
+  ],
   "exports": {
     ".": {
-      "import": "./dist/continuous-carousel.esm.js",
-      "require": "./dist/continuous-carousel.js"
-    }
+      "import": {
+        "types": "./types/index.d.ts",
+        "default": "./dist/continuous-carousel.esm.js"
+      },
+      "require": {
+        "types": "./types/index.d.ts",
+        "default": "./dist/continuous-carousel.js"
+      }
+    },
+    "./css": "./dist/continuous-carousel.min.css"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Add `lint` + `test` steps to deploy workflow before build
- Add PR validation workflow (`ci.yml`) — runs on PRs to main
- Add `types`, `sideEffects`, `files`, `keywords` to package.json
- Add conditional `exports` with TypeScript types + CSS entry (`./css`)

## Test plan
- [ ] Push branch, confirm CI workflow runs on this PR
- [ ] Merge, confirm deploy workflow runs lint + test before deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)