### PR TITLE
ci: add npm publish workflow on tag push

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,40 @@
+name: Publish to npm
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm test
+
+      - name: Publish
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- New `publish.yml` workflow triggers on `v*` tag push
- Runs lint → build → test → `npm publish --provenance --access public`
- Uses `NPM_TOKEN` secret (already configured)

## Release flow
1. `npm version patch|minor|major`
2. Fill in changelog entries
3. Commit changelog
4. `git push origin main --tags`
5. Workflow auto-publishes to npm

## Test plan
- [ ] Push a test tag to verify workflow triggers (use `--dry-run` first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)