### PR TITLE
fix(ci): auto-merge dependabot major version bumps

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -18,7 +18,8 @@ jobs:
       - name: Approve PR
         if: >-
           steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
-          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+          steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-major'
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
@@ -26,7 +27,8 @@ jobs:
       - name: Enable auto-merge
         if: >-
           steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
-          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+          steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-major'
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
## Summary

- The Dependabot auto-merge workflow only handled `semver-patch` and `semver-minor` bumps, which caused major version PRs (e.g. `actions/checkout` 6→7, `@babel/core` 7→8) to be silently skipped — never approved or auto-merged.
- This PR extends both the **Approve PR** and **Enable auto-merge** step conditions to also include `version-update:semver-major`.
- Safety is preserved: `gh pr merge --auto` already waits for all required CI checks to pass before merging, so major bumps will only land once the test suite is green.

## Test plan

- [ ] Open a new Dependabot PR that represents a major version bump and confirm the workflow approves and queues it for auto-merge.
- [ ] Confirm patch/minor PRs continue to behave as before.
- [ ] Confirm `gh pr merge --auto` blocks the merge if CI fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)